### PR TITLE
Update ElasticSearch client to a recent version

### DIFF
--- a/src/ElasticSearch.Extensions.Logging/ElasticSearch.Extensions.Logging.csproj
+++ b/src/ElasticSearch.Extensions.Logging/ElasticSearch.Extensions.Logging.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>AM.ElasticSearch.Extensions.Logging</PackageId>
-    <Version>1.0.3</Version>
-    <PackageVersion>1.0.3</PackageVersion>
+    <Version>1.1.0</Version>
+    <PackageVersion>1.1.0</PackageVersion>
     <PackageVersionPrefix>x</PackageVersionPrefix>
     <PackageVersionSuffix>x</PackageVersionSuffix>
     <Authors>amccool</Authors>
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elasticsearch.Net" Version="2.5.8" />
+    <PackageReference Include="Elasticsearch.Net" Version="6.3.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Reactive.Linq" Version="3.1.0" />


### PR DESCRIPTION
This package uses an ancient version of the `Elasticsearch.Net` package, and claims that it accepts any major version above. This causes runtime errors due to methods that no longer exist.
I have updated the package and made the necessary adjustments.
I've bumped the minor version of the package, but I don't know if that's how you want to version this, so please change this as you see fit.