### PR TITLE
Smaller Request Timeout

### DIFF
--- a/src/ElasticLogger.Test/ElasticLogger.Test.csproj
+++ b/src/ElasticLogger.Test/ElasticLogger.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -13,6 +13,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.*"/>
+
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="NEST" Version="2.5.8" />
     <PackageReference Include="xunit" Version="2.4.1" />
@@ -25,12 +27,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ElasticSearch.Extensions.Logging\AM.Extensions.Logging.ElasticSearch.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions">
-      <HintPath>C:\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.extensions.logging.abstractions\2.0.1\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
-    </Reference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ElasticLogger.Test/ElasticsearchLoggerFilterTests.cs
+++ b/src/ElasticLogger.Test/ElasticsearchLoggerFilterTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using AM.Extensions.Logging.ElasticSearch;

--- a/src/ElasticSearch.Extensions.Logging/ElasticSearchLogger.cs
+++ b/src/ElasticSearch.Extensions.Logging/ElasticSearchLogger.cs
@@ -241,7 +241,8 @@ namespace AM.Extensions.Logging.ElasticSearch
             }
             catch (Exception ex)
             {
-                Debug.WriteLine(ex);
+                //this is of questionable value
+                //Debug.WriteLine(ex.Message);
             }
         }
 

--- a/src/ElasticSearch.Extensions.Logging/ElasticSearchLoggerProvider.cs
+++ b/src/ElasticSearch.Extensions.Logging/ElasticSearchLoggerProvider.cs
@@ -69,6 +69,7 @@ namespace AM.Extensions.Logging.ElasticSearch
 
                     var cc = new ConnectionConfiguration(singleNode,
                             connectionSettings => new ElasticsearchJsonNetSerializer())
+                        .RequestTimeout(TimeSpan.FromSeconds(15))
                         .EnableHttpPipelining()
                         .ThrowExceptions();
 
@@ -140,7 +141,8 @@ namespace AM.Extensions.Logging.ElasticSearch
             }
             catch (Exception ex)
             {
-                Debug.WriteLine(ex);
+                //eat the exception, we cant really do much with it anyways
+                //Debug.WriteLine(ex.Message);
             }
         }
 


### PR DESCRIPTION
reduce timeout timespan from default of 60s to 15s to reduce pressure under load.

remove the Debug.WriteLine in the exceptions